### PR TITLE
Fixes a recursion issue when teleported out of a cuboid.

### DIFF
--- a/src/main/java/net/playblack/cuboids/impl/canarymod/PlayerListener.java
+++ b/src/main/java/net/playblack/cuboids/impl/canarymod/PlayerListener.java
@@ -64,16 +64,17 @@ public class PlayerListener implements PluginListener {
         if (!player.getWorld().isChunkLoaded((int) to.getX(), (int) to.getZ())) {
             player.getWorld().loadChunk((int) to.getX(), (int) to.getZ());
         }
+        /*
         CLocation vTo = new CLocation(to.getX(), to.getY(), to.getZ(), to.getType().getId(), to.getWorldName());
         ToolBox.adjustWorldPosition(vTo);
         CLocation vFrom = new CLocation(from.getX(), from.getY(), from.getZ(), from.getType().getId(), from.getWorldName());
         ToolBox.adjustWorldPosition(vFrom);
 
-        PlayerWalkEvent event = new PlayerWalkEvent(player, vFrom, vTo);
+         PlayerWalkEvent event = new PlayerWalkEvent(player, vFrom, vTo);
         ActionManager.fireEvent(event);
         if (event.isCancelled()) {
             hook.setCanceled();
-        }
+        } */
     }
 
     @HookHandler


### PR DESCRIPTION
When being teleported out of a cuboid, there was a recursion issue
that causes a stackoverflow.

No code added, several lines commented.

---

I admit that the edit is pretty heavy-handed, and I don't fully understand the reason for the chunk I commented out, but things seem to be working as expected.
