### PR TITLE
API / Plugin mismatch.

### DIFF
--- a/src/main/java/net/playblack/cuboids/actions/operators/OperableItemsOperator.java
+++ b/src/main/java/net/playblack/cuboids/actions/operators/OperableItemsOperator.java
@@ -38,7 +38,7 @@ public class OperableItemsOperator implements ActionListener {
             return true;
         }
         Region r = RegionManager.get().getActiveRegion(point, false);
-        return r.playerIsAllowed(player.getName(), player.getGroups()) || !r.isItemRestricted(block.getId());
+        return r.playerIsAllowed(player.getName(), player.getGroups()) || !r.isItemRestricted(String.valueOf(block.getId()));
     }
 
     public boolean canUseBucket(CPlayer player, CLocation point, boolean lavaBucket) {


### PR DESCRIPTION
Caused by: java.lang.UnsupportedOperationException: Deprecated. Use strings instead of ints!
        at net.playblack.cuboids.regions.Region.isItemRestricted(Region.java:894) ~[?:?]
        at net.playblack.cuboids.actions.operators.OperableItemsOperator.canUseBlock(OperableItemsOperator.java:41) ~[?:?]
        at net.playblack.cuboids.actions.operators.OperableItemsOperator.onBlockRightClick(OperableItemsOperator.java:64)
